### PR TITLE
Add support for MLprogram in ort_coreml

### DIFF
--- a/.github/workflows/macos-ort.yml
+++ b/.github/workflows/macos-ort.yml
@@ -103,7 +103,7 @@ jobs:
 
     - name: Setup ONNX Runtime
       run: |
-        curl -L -o ort.tgz https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-osx-arm64-1.19.2.tgz
+        curl -L -o ort.tgz https://github.com/microsoft/onnxruntime/releases/download/v1.20.0/onnxruntime-osx-arm64-1.20.0.tgz
         tar -xf ort.tgz
         mv onnxruntime-* onnxruntime
 

--- a/.github/workflows/macos-ort.yml
+++ b/.github/workflows/macos-ort.yml
@@ -131,7 +131,7 @@ jobs:
         cp -v install/lib/*.dylib artifact
 
     - name: Describe
-      run: git describe --tags --long
+      run: git describe --tags --long --always
 
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-ort.yml
+++ b/.github/workflows/macos-ort.yml
@@ -131,7 +131,7 @@ jobs:
         cp -v install/lib/*.dylib artifact
 
     - name: Describe
-      run: git describe --tags --long --always
+      run: git describe --tags --long
 
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/scripts/vsmlrt.py
+++ b/scripts/vsmlrt.py
@@ -273,7 +273,7 @@ class Backend:
         verbosity: int = 0
         fp16: bool = False
         fp16_blacklist_ops: typing.Optional[typing.Sequence[str]] = None
-        MLprogram: int = 0
+        ml_program: int = 0
 
         # internal backend attributes
         supports_onnx_serialization: bool = True
@@ -2481,7 +2481,7 @@ def _inference(
             fp16=backend.fp16,
             path_is_serialization=path_is_serialization,
             fp16_blacklist_ops=backend.fp16_blacklist_ops,
-            MLprogram=backend.MLprogram,
+            ml_program=backend.ml_program,
             **kwargs
         )
     elif isinstance(backend, Backend.ORT_CUDA):

--- a/scripts/vsmlrt.py
+++ b/scripts/vsmlrt.py
@@ -273,6 +273,7 @@ class Backend:
         verbosity: int = 0
         fp16: bool = False
         fp16_blacklist_ops: typing.Optional[typing.Sequence[str]] = None
+        MLprogram: int = 0
 
         # internal backend attributes
         supports_onnx_serialization: bool = True
@@ -2480,6 +2481,7 @@ def _inference(
             fp16=backend.fp16,
             path_is_serialization=path_is_serialization,
             fp16_blacklist_ops=backend.fp16_blacklist_ops,
+            MLprogram=backend.MLprogram,
             **kwargs
         )
     elif isinstance(backend, Backend.ORT_CUDA):

--- a/vsort/README.md
+++ b/vsort/README.md
@@ -30,9 +30,6 @@ Arguments:
    - `"DML"`: DirectML backend
    - `"COREML"`: CoreML backend
  - `int device_id`: select the GPU device for the CUDA backend.'
- - `int MLprogram`: select CoreML provider.
-   - 0: NeuralNetwork
-   - 1: MLProgram
  - `int verbosity`: specify the verbosity of logging, the default is warning.
    - 0: fatal error only, `ORT_LOGGING_LEVEL_FATAL`
    - 1: also errors, `ORT_LOGGING_LEVEL_ERROR`
@@ -45,6 +42,9 @@ Arguments:
  - `bint fp16`: whether to quantize model to fp16 for faster and memory efficient computation.
  - `bint path_is_serialization`: whether the `network_path` argument specifies an onnx serialization of type `bytes`.
  - `bint use_cuda_graph`: whether to use CUDA Graphs to improve performance and reduce CPU overhead in CUDA backend. Not all models are supported.
+ - `int ml_program`: select CoreML provider.
+   - 0: NeuralNetwork
+   - 1: MLProgram
 
 When `overlap` and `tilesize` are not specified, the filter will internally try to resize the network to fit the input clips. This might not always work (for example, the network might require the width to be divisible by 8), and the filter will error out in this case.
 

--- a/vsort/README.md
+++ b/vsort/README.md
@@ -27,7 +27,12 @@ Arguments:
  - `string provider`: Specifies the device to run the inference on.
    - `"CPU"` or `""`: pure CPU backend
    - `"CUDA"`: CUDA GPU backend, requires Nvidia Maxwell+ GPUs.
- - `int device_id`: select the GPU device for the CUDA backend.
+   - `"DML"`: DirectML backend
+   - `"COREML"`: CoreML backend
+ - `int device_id`: select the GPU device for the CUDA backend.'
+ - `int MLprogram`: select CoreML provider.
+   - 0: NeuralNetwork
+   - 1: MLProgram
  - `int verbosity`: specify the verbosity of logging, the default is warning.
    - 0: fatal error only, `ORT_LOGGING_LEVEL_FATAL`
    - 1: also errors, `ORT_LOGGING_LEVEL_ERROR`

--- a/vsort/vs_onnxruntime.cpp
+++ b/vsort/vs_onnxruntime.cpp
@@ -455,7 +455,7 @@ struct vsOrtData {
     std::unique_ptr<VSVideoInfo> out_vi;
 
 #ifdef ENABLE_COREML
-    bool MLprogram;
+    bool ml_program;
 #endif //ENABLE_COREML
 
     int overlap_w, overlap_h;
@@ -913,16 +913,16 @@ static void VS_CC vsOrtCreate(
         verbosity = ORT_LOGGING_LEVEL_WARNING;
     }
 #ifdef ENABLE_COREML
-    auto MLprogram = vsapi->propGetInt(in, "MLprogram", 0, &error);
+    auto ml_program = vsapi->propGetInt(in, "ml_program", 0, &error);
 
     if (error) {
-        d->MLprogram = false;
-    } else if (MLprogram == 0) {
-        d->MLprogram = false;
-    } else if (MLprogram == 1) {
-        d->MLprogram = true;
+        d->ml_program = false;
+    } else if (ml_program == 0) {
+        d->ml_program = false;
+    } else if (ml_program == 1) {
+        d->ml_program = true;
     } else {
-        return set_error("\"MLprogram\" must be 0 or 1");
+        return set_error("\"ml_program\" must be 0 or 1");
     }
 #endif //ENABLE_COREML
 
@@ -1250,7 +1250,7 @@ static void VS_CC vsOrtCreate(
 #endif // ENABLE_CUDA
 #ifdef ENABLE_COREML
         uint32_t coreml_flag = 0;
-        if (MLprogram) coreml_flag |= 0x010;
+        if (ml_program) coreml_flag |= 0x010;
         if (d->backend == Backend::COREML) {
             checkError(OrtSessionOptionsAppendExecutionProvider_CoreML(
                 session_options,
@@ -1415,9 +1415,6 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "tilesize:int[]:opt;"
         "provider:data:opt;" // "": Default (CPU), "CUDA": CUDA, "COREML": COREML, "DML": DML
         "device_id:int:opt;"
-#ifdef ENABLE_COREML
-        "MLprogram:int:opt;"
-#endif //ENABLE_COREML
         "num_streams:int:opt;"
         "verbosity:int:opt;"
         "cudnn_benchmark:int:opt;"
@@ -1431,6 +1428,9 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "output_format:int:opt;"
         "tf32:int:opt;"
         "flexible_output_prop:data:opt;"
+#ifdef ENABLE_COREML
+        "ml_program:int:opt;"
+#endif //ENABLE_COREML
         , vsOrtCreate,
         nullptr,
         plugin


### PR DESCRIPTION
Onnxruntime supports two Core ML execution providers: NeuralNetwork and MLProgram. The NeuralNetwork provider is the default choice as it supports a wider range of operators, but it does not support FP16 precision (so all nodes falls to CPUExecutionProvider).

The MLProgram provider, while newer and currently supporting fewer operators, does support FP16 and is under active development. (Recent GitHub PRs suggest that it will mature rapidly, adding tens of new operators). Although it might be slower now due to limited operator support, once it achieves comprehensive coverage, the potential CPU/GPU acceleration through FP16 could make it perform better than the NeuralNetwork provider.

In Onnxruntime, the ONNX model is converted to a Core ML model and saved to disk, which is then loaded via Apple's CoreML framework. By choosing FP16 inputs with the MLProgram provider, we can significantly reduce both memory and disk usage as the Core ML model will be stored in a more compact FP16 format. While the ANE always performs computations in FP16 internally regardless of input precision, making FP16 acceleration unnecessary for the neural engine itself, the storage benefits remain valuable.

Moreover, FP16 inputs may accelerate computations on GPU and CPU, as both support FP16 (though not enabled by default). However, the exact behavior of FP16 handling in Onnxruntime remains unclear due to its complex execution flow: ORT first decides which nodes to assign to CoreML, uses CPUExecutionProvider for the rest, and then CoreML further distributes its nodes among CPU, GPU, and ANE.


---
For more details on FP16 behavior, refer to this documentation: [16-bit precision in Core ML on ANE](https://github.com/hollance/neural-engine/blob/master/docs/16-bit.md).

ML Program relevant PRs: https://github.com/microsoft/onnxruntime/pull/19347 https://github.com/microsoft/onnxruntime/pull/22068 https://github.com/microsoft/onnxruntime/pull/22480   https://github.com/microsoft/onnxruntime/pull/22710 and so on.