### PR TITLE
fix: use correct path for checking alter engine size

### DIFF
--- a/scripts/vsmlrt.py
+++ b/scripts/vsmlrt.py
@@ -2049,7 +2049,7 @@ def trtexec(
             os.path.splitdrive(engine_path)[1][1:]
         )
 
-        if os.access(alter_engine_path, mode=os.R_OK) and os.path.getsize(engine_path) >= 1024:
+        if os.access(alter_engine_path, mode=os.R_OK) and os.path.getsize(alter_engine_path) >= 1024:
             return alter_engine_path
 
     try:
@@ -2451,7 +2451,7 @@ def tensorrt_rtx(
             os.path.splitdrive(engine_path)[1][1:]
         )
 
-        if os.access(alter_engine_path, mode=os.R_OK) and os.path.getsize(engine_path) >= 1024:
+        if os.access(alter_engine_path, mode=os.R_OK) and os.path.getsize(alter_engine_path) >= 1024:
             return alter_engine_path
 
     try:


### PR DESCRIPTION
Currently when `engine_folder` is not specified and `engine_path` is not usable, the check for `os.path.getsize` is using the incorrect variable (`engine_path` instead of `alter_engine_path`) which leads to a crash. Replacing this with the correct variable avoids the crash and allows the code to run as expected.