### PR TITLE
Remove dependency on the PickFrames function in akarin 0.96g

### DIFF
--- a/scripts/vsmlrt.py
+++ b/scripts/vsmlrt.py
@@ -3432,5 +3432,6 @@ def _expr(
 def _pick_frames(clip: vs.VideoNode, indices: typing.List[int]) -> vs.VideoNode:
     try:
         return core.akarin.PickFrames(clip, indices)
-    except vs.Error:
+    # vs.Error raised by missing akarin plugin is already checked before calling this function
+    except AttributeError:
         return clip.std.SelectEvery(cycle=clip.num_frames, offsets=indices)


### PR DESCRIPTION
`PickFrames` function is never open-sourced and only exists in windows x86 only binary releases. By adding a helper function `_pick_frames()`, it automatically determines between `std.SelectEvery` and `akarin.PickFrames` for better compatibility.